### PR TITLE
Use a (much) quicker WASM compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ cargo build --target wasm32-wasi --release
 cd ..
 cp ext/target/wasm32-wasi/release/http.wasm rust-host
 cd rust-host
-cargo run
+cargo +nightly run
 ```
 

--- a/rust-host/Cargo.lock
+++ b/rust-host/Cargo.lock
@@ -404,6 +404,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "dynasm"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a814e1edeb85dd2a3c6fc0d6bf76d02ca5695d438c70ecee3d90774f3259c5"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "owning_ref",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a393aaeb4441a48bcf47b5b6155971f82cc1eb77e22855403ccc0415ac8328d"
+dependencies = [
+ "byteorder",
+ "memmap",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1580,7 @@ dependencies = [
  "url",
  "wasmer-runtime",
  "wasmer-runtime-core",
+ "wasmer-singlepass-backend",
  "wasmer-wasi",
 ]
 
@@ -1776,6 +1811,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
@@ -2342,6 +2383,25 @@ dependencies = [
  "target-lexicon",
  "wasmparser",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "wasmer-singlepass-backend"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a434ebf512ae1c76de46d41935a9ae10775fd937071334bdf5878cc41d9140"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "dynasm",
+ "dynasmrt",
+ "lazy_static",
+ "libc",
+ "nix",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "wasmer-runtime-core",
 ]
 
 [[package]]

--- a/rust-host/Cargo.toml
+++ b/rust-host/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 wasmer-runtime-core = "0.17.1"
 wasmer-runtime = "0.17.1"
+wasmer-singlepass-backend = "0.17.1"
 wasmer-wasi = "0.17.1"
 reqwest = { version = "0.10", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "0.2", features = ["full"] }

--- a/rust-host/src/main.rs
+++ b/rust-host/src/main.rs
@@ -3,7 +3,8 @@ mod utils;
 
 use kube::Config;
 use std::cell::RefCell;
-use wasmer_runtime::{compile, error, func, imports, Func};
+use wasmer_runtime::{compile_with, error, func, imports, Func};
+use wasmer_singlepass_backend::SinglePassCompiler;
 
 // Make sure that the compiled wasm-sample-app is accessible at this path.
 static WASM: &'static [u8] = include_bytes!("../http.wasm");
@@ -24,7 +25,7 @@ fn main() -> error::Result<()> {
         .expect("Cannot build the http client from the kubeconfig");
     let ref_cell_runtime = RefCell::new(runtime);
 
-    let (module, duration) = execution_time!({ compile(WASM).expect("wasm compilation") });
+    let (module, duration) = execution_time!({ compile_with(WASM, &SinglePassCompiler::new()).expect("wasm compilation") });
     println!("Compilation time duration: {} ms", duration.as_millis());
 
     // get the version of the WASI module in a non-strict way, meaning we're


### PR DESCRIPTION
This reduces the amount of time needed to compile the WASM module to ~8s on my machine (down from 30-60).