### PR TITLE
Added delay

### DIFF
--- a/ext-simple-pod/src/lib.rs
+++ b/ext-simple-pod/src/lib.rs
@@ -2,7 +2,7 @@ use k8s_openapi::api::core::v1::{Container, Pod, PodSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::{ListParams, Meta, PostParams, WatchEvent};
 use kube::runtime::Informer;
-use kube::{Api, Client};
+use kube::{Api, Client, abi};
 use futures::task::SpawnExt;
 
 use kube::CustomResource;
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::BorrowMut;
 use std::ops::Deref;
 use futures::{pin_mut, TryStreamExt};
+use std::time::{Duration, Instant};
 
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
 #[kube(group = "slinky.dev", version = "v1", namespaced)]
@@ -29,6 +30,10 @@ pub extern "C" fn run() {
         let foos: Api<SimplePod> = Api::namespaced(client.clone(), "default");
         let inform = Informer::new(foos).params(ListParams::default());
         let pods: Api<Pod> = Api::namespaced(client.clone(), "default");
+
+        println!("Waiting 10 seconds: {:?}", Instant::now());
+        abi::register_delay(Duration::from_secs(10)).await;
+        println!("10 seconds passed: {:?}", Instant::now());
 
         let mut stream = inform.poll().await.unwrap();
         pin_mut!(stream);

--- a/kube-rs/src/abi/delay.rs
+++ b/kube-rs/src/abi/delay.rs
@@ -1,0 +1,16 @@
+use std::future::Future;
+use std::time::Duration;
+use futures::FutureExt;
+
+#[link(wasm_import_module = "delay-abi")]
+extern "C" {
+    // Returns the future identifier
+    fn delay(millis: u64) -> u64;
+}
+
+pub fn register_delay(del: Duration) -> impl Future<Output=()> {
+    let millis = del.as_millis() as u64;
+    super::start_future(
+        unsafe { delay(millis) }
+    ).map(|v| ())
+}

--- a/kube-rs/src/abi/mod.rs
+++ b/kube-rs/src/abi/mod.rs
@@ -2,9 +2,11 @@ mod http;
 mod kube_watch;
 mod memory;
 mod executor;
+mod delay;
 
 pub use crate::abi::http::execute_request;
 pub use kube_watch::register_watch;
+pub use delay::register_delay;
 pub use executor::get_mut_executor;
 pub use executor::start_stream;
 pub use executor::start_future;

--- a/rust-host/Cargo.toml
+++ b/rust-host/Cargo.toml
@@ -16,9 +16,9 @@ log = "0.4.0"
 wasmer-runtime = "0.17.1"
 wasmer-singlepass-backend = "0.17.1"
 wasmer-wasi = "0.17.1"
-reqwest = { version = "0.10", default-features = false, features = ["json", "rustls-tls"] }
-tokio = { version = "0.2", features = ["full"] }
-http = "0.2"
+reqwest = { version = "^0.10", default-features = false, features = ["json", "rustls-tls"] }
+tokio = { version = "^0.2", features = ["full"] }
+http = "^0.2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_yaml = "^0.8"

--- a/rust-host/src/abi/mod.rs
+++ b/rust-host/src/abi/mod.rs
@@ -6,6 +6,7 @@ use wasmer_runtime::{ImportObject, Instance};
 use dispatcher::AsyncType;
 use std::fmt::Debug;
 use crate::abi::commands::AbiCommand;
+use std::time::Duration;
 
 #[cfg(feature = "abi-rust-v1alpha1")]
 pub(crate) mod rust_v1alpha1;
@@ -15,6 +16,7 @@ pub mod commands;
 
 pub struct AbiConfig {
     pub http_command_sender: UnboundedSender<AbiCommand<http::Request<Vec<u8>>>>,
+    pub delay_command_sender: UnboundedSender<AbiCommand<Duration>>,
     pub watch_command_sender: UnboundedSender<AbiCommand<WatchKey>>,
 }
 

--- a/rust-host/src/delay/mod.rs
+++ b/rust-host/src/delay/mod.rs
@@ -1,0 +1,27 @@
+use tokio::sync::mpsc::{Sender, UnboundedReceiver};
+use crate::abi::commands::AbiCommand;
+use crate::abi::dispatcher::{AsyncType, AsyncResult};
+use std::convert::{TryFrom, TryInto};
+use http::HeaderMap;
+
+use crate::abi::rust_v1alpha1::HttpResponse;
+use futures::{StreamExt};
+use std::time::Duration;
+
+pub async fn start_delay_executor(
+    rx: UnboundedReceiver<AbiCommand<Duration>>,
+    tx: Sender<AsyncResult>,
+) -> anyhow::Result<()> {
+    rx.for_each_concurrent(10, |mut duration| async {
+        tokio::time::delay_for(duration.value.into()).await;
+
+        tx.clone().send(AsyncResult {
+            async_request_id: duration.async_request_id,
+            controller_name: duration.controller_name,
+            value: None,
+            async_type: AsyncType::Future
+        }).await.expect("Send error");
+
+    }).await;
+    Ok(())
+}


### PR DESCRIPTION
Delay functionality is required to make the controller runtime working, since it uses delays to synchronize the internal cache and reque reconciliation messages

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>